### PR TITLE
Adds focus style change for buttons

### DIFF
--- a/scss/elements/buttons.scss
+++ b/scss/elements/buttons.scss
@@ -3,7 +3,8 @@
   background-color: $background;
   box-shadow: inset -4px -4px $shadow;
 
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: $hover-background;
     box-shadow: inset -6px -6px $shadow;
   }


### PR DESCRIPTION
This PR allows users navigating by <kbd>Tab</kbd> to visually have an idea of where they are in the DOM.

By giving `button`s the same visual style as if they were hovered by a mouse, people who navigate by use of non-mouse input devices (keyboards) will have a visual cue of where keyboard focus presently is in the document.

closes #22
