### PR TITLE
disable font-smoothing 

### DIFF
--- a/scss/base/generic.scss
+++ b/scss/base/generic.scss
@@ -13,6 +13,7 @@ body {
   font-size: $font-size;
   color: $base-color;
   background-color: $background-color;
+  -webkit-font-smoothing : none;
 }
 
 button,

--- a/scss/base/reboot.scss
+++ b/scss/base/reboot.scss
@@ -17,6 +17,7 @@ html {
   -webkit-text-size-adjust: 100%;
   -ms-overflow-style: scrollbar;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-font-smoothing : none;
 }
 
 @-ms-viewport {

--- a/scss/base/reboot.scss
+++ b/scss/base/reboot.scss
@@ -17,7 +17,6 @@ html {
   -webkit-text-size-adjust: 100%;
   -ms-overflow-style: scrollbar;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  -webkit-font-smoothing : none;
 }
 
 @-ms-viewport {


### PR DESCRIPTION
Just a tiny change to remove the anti-aliasing from the font :)

Currently:
![screen shot 2018-11-30 at 10 33 38](https://user-images.githubusercontent.com/271631/49280916-98716580-f48b-11e8-83a3-baf13e6748fc.png)

Without font-smoothing:
![screen shot 2018-11-30 at 10 33 54](https://user-images.githubusercontent.com/271631/49280917-98716580-f48b-11e8-9f21-6cc2c55aa487.png)
